### PR TITLE
New actions.

### DIFF
--- a/.github/workflows/R-CMD-Check.yml
+++ b/.github/workflows/R-CMD-Check.yml
@@ -49,6 +49,8 @@ jobs:
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
+          args: 'c("--as-cran")'
+          build_args: 'c()'
 
       - name: Test coverage
         run: covr::codecov()

--- a/.github/workflows/R-CMD-Check.yml
+++ b/.github/workflows/R-CMD-Check.yml
@@ -43,7 +43,7 @@ jobs:
             use-public-rspm: true
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, any::covr, any::devtools, any::pkgdown
+          extra-packages: any::rcmdcheck, any::covr, any::devtools, any::pkgdown, any::BH
           needs: check, coverage
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/R-CMD-Check.yml
+++ b/.github/workflows/R-CMD-Check.yml
@@ -21,7 +21,6 @@ jobs:
     runs-on: ${{ matrix.config.os }}
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       _R_CHECK_TESTS_NLINES_: 0
       NOT_CRAN: true
       HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: true
@@ -45,6 +44,8 @@ jobs:
         with:
           extra-packages: any::rcmdcheck, any::covr, any::devtools, any::pkgdown
           needs: check, coverage
+        env:
+          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/.github/workflows/R-CMD-Check.yml
+++ b/.github/workflows/R-CMD-Check.yml
@@ -45,24 +45,3 @@ jobs:
       - name: Test coverage
         run: covr::codecov()
         shell: Rscript {0}
-        
-      - name: Build docs
-        run: |
-          Rscript -e 'devtools::document(); pkgdown::build_site(new_process = FALSE)'
-          touch docs/.nojekyll
-      - uses: actions/upload-pages-artifact@v1
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        with:
-          path: ./docs
-  # 
-  # deploy:
-  #   runs-on: ubuntu-latest
-  #   needs: pre_deploy
-  #   environment:
-  #     name: github-pages
-  #     url: ${{ steps.deployment.outputs.page_url }}
-  #   steps:
-  #     - name: Deploy to GitHub Pages
-  #       id: deployment
-  #       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-  #       uses: actions/deploy-pages@v1

--- a/.github/workflows/R-CMD-Check.yml
+++ b/.github/workflows/R-CMD-Check.yml
@@ -9,7 +9,7 @@ on:
 name: R-CMD-check
 
 jobs:
-  pre_deploy:
+  check:
     runs-on: ${{ matrix.config.os }}
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/.github/workflows/R-CMD-Check.yml
+++ b/.github/workflows/R-CMD-Check.yml
@@ -43,14 +43,12 @@ jobs:
             use-public-rspm: true
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, any::covr, any::devtools, any::pkgdown, any::BH
+          extra-packages: any::rcmdcheck, any::covr, any::devtools, any::pkgdown
           needs: check, coverage
 
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
-          args: 'c("--as-cran")'
-          build_args: 'c()'
 
       - name: Test coverage
         run: covr::codecov()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
             use-public-rspm: true
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, any::covr, any::devtools
+          extra-packages: any::rcmdcheck, any::covr, any::devtools, any::pkgdown
           needs: check, coverage
 
       - uses: r-lib/actions/check-r-package@v2
@@ -46,20 +46,14 @@ jobs:
         run: covr::codecov()
         shell: Rscript {0}
         
-      # Needed?
-      # - name: Downgrade pkgdown
-      #   run: |
-      #     remotes::install_version("pkgdown", "2.0.3")
-      #   shell: Rscript {0}
-  #       
-  #     - name: Build docs
-  #       run: |
-  #         Rscript -e 'devtools::document(); pkgdown::build_site(new_process = FALSE)'
-  #         touch docs/.nojekyll
-  #     - uses: actions/upload-pages-artifact@v1
-  #       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-  #       with:
-  #         path: ./docs
+      - name: Build docs
+        run: |
+          Rscript -e 'devtools::document(); pkgdown::build_site(new_process = FALSE)'
+          touch docs/.nojekyll
+      - uses: actions/upload-pages-artifact@v1
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        with:
+          path: ./docs
   # 
   # deploy:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,12 @@
-name: R
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
-on: [push, pull_request]
-
-
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+name: R-CMD-check
 
 jobs:
   pre_deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
             use-public-rspm: true
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, any::covr
+          extra-packages: any::rcmdcheck, any::covr, any::devtools
           needs: check, coverage
 
       - uses: r-lib/actions/check-r-package@v2
@@ -51,24 +51,24 @@ jobs:
       #   run: |
       #     remotes::install_version("pkgdown", "2.0.3")
       #   shell: Rscript {0}
-        
-      - name: Build docs
-        run: |
-          Rscript -e 'devtools::document(); pkgdown::build_site(new_process = FALSE)'
-          touch docs/.nojekyll
-      - uses: actions/upload-pages-artifact@v1
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        with:
-          path: ./docs
-
-  deploy:
-    runs-on: ubuntu-latest
-    needs: pre_deploy
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        uses: actions/deploy-pages@v1
+  #       
+  #     - name: Build docs
+  #       run: |
+  #         Rscript -e 'devtools::document(); pkgdown::build_site(new_process = FALSE)'
+  #         touch docs/.nojekyll
+  #     - uses: actions/upload-pages-artifact@v1
+  #       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+  #       with:
+  #         path: ./docs
+  # 
+  # deploy:
+  #   runs-on: ubuntu-latest
+  #   needs: pre_deploy
+  #   environment:
+  #     name: github-pages
+  #     url: ${{ steps.deployment.outputs.page_url }}
+  #   steps:
+  #     - name: Deploy to GitHub Pages
+  #       id: deployment
+  #       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+  #       uses: actions/deploy-pages@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,62 +10,48 @@ permissions:
 
 jobs:
   pre_deploy:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.config.os }}
     env:
-      cache-version: 5
+      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      _R_CHECK_TESTS_NLINES_: 0
+      NOT_CRAN: true
+      HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: true
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: macos-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up libraries for Ubuntu
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libsodium-dev libharfbuzz-dev libfribidi-dev libcurl4-openssl-dev texlive-latex-base texlive-fonts-extra pandoc libmagick++-dev libhdf5-dev
-      - name: Set up R 4.0
-        uses: r-lib/actions/setup-r@v2
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: 4.0
-      - name: Set CRAN mirror
-        run: |
-          cat("\noptions(repos=structure(c(CRAN=\"https://cran.rstudio.com\")))\n", file = "~/.Rprofile", append = TRUE)
-        shell: Rscript {0}
-      - name: Get R and OS version
-        id: get-version
-        run: |
-          cat("::set-output name=os-version::", sessionInfo()$running, "\n", sep = "")
-          cat("::set-output name=r-version::", R.Version()$version.string, "\n", sep = "")
-          cat("::endgroup::\n")
-        shell: Rscript {0}
-      - name: Cache dependencies
-        id: cache-deps
-        uses: actions/cache@v2
+            r-version: ${{ matrix.config.r }}
+            use-public-rspm: true
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          path: ${{ env.R_LIBS_USER }}/*
-          key: ${{ hashFiles('DESCRIPTION') }}-${{ steps.get-version.outputs.os-version }}-${{ steps.get-version.outputs.r-version }}-${{ env.cache-version }}-deps
-      - name: Install dependencies
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: |
-          install.packages(c("devtools", "remotes", "rcmdcheck", "BiocManager", "covr"))
-          BiocManager::install("Rarr")
-          remotes::install_deps(dependencies = TRUE)
+          extra-packages: any::rcmdcheck, any::covr
+          needs: check, coverage
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+
+      - name: Test coverage
+        run: covr::codecov()
         shell: Rscript {0}
-        env:
-          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      - name: rcmdcheck
-        run: |
-          rcmdcheck::rcmdcheck(
-            error_on = "error", # TODO: switch back to "warning"
-            check_dir = "check"
-          )
-        shell: Rscript {0}
-        env:
-          _R_CHECK_FORCE_SUGGESTS_: false
-      - name: Run coverage report
-        run: |
-          covr::package_coverage()
-        shell: Rscript {0}
-      - name: Downgrade pkgdown
-        run: |
-          remotes::install_version("pkgdown", "2.0.3")
-        shell: Rscript {0}
+        
+      # Needed?
+      # - name: Downgrade pkgdown
+      #   run: |
+      #     remotes::install_version("pkgdown", "2.0.3")
+      #   shell: Rscript {0}
+        
       - name: Build docs
         run: |
           Rscript -e 'devtools::document(); pkgdown::build_site(new_process = FALSE)'

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -26,7 +26,6 @@ jobs:
     concurrency:
       group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       CUSTOM_DR_UA: 'GitHub_CI'
     steps:
       - uses: actions/checkout@v3
@@ -41,6 +40,8 @@ jobs:
         with:
           extra-packages: any::pkgdown, any::devtools, local::.
           needs: website
+        env:
+          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build site
         run: |
@@ -48,6 +49,8 @@ jobs:
           pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE, dest_dir = "public") |
           file.copy(from = "./public/articles/logo.png",to = "./public/reference/logo.png")
         shell: Rscript {0}
+        env:
+          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   pkgdown:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     # Only restrict concurrency for non-PR jobs
     concurrency:
       group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
@@ -29,26 +29,27 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       CUSTOM_DR_UA: 'GitHub_CI'
     steps:
-      - uses: actions/checkout@c0a81a463886bb75afe234e07a9fd5bb79219196
+      - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-pandoc@52330cc136b963487918a8867f948ddf954e9e63
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@52330cc136b963487918a8867f948ddf954e9e63
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@52330cc136b963487918a8867f948ddf954e9e63
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown, local::.
+          extra-packages: any::pkgdown, any::devtools, local::.
           needs: website
 
       - name: Build site
         run: |
+          devtools::install_dev_deps()
           pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE, dest_dir = "public") |
           file.copy(from = "./public/articles/logo.png",to = "./public/reference/logo.png")
         shell: Rscript {0}
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@64bcae551a7b18bcb9a09042ddf1960979799187
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./public
   # Deployment job
@@ -61,4 +62,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@73e62e651178eeba977de2dc9f4c7645b3d01015
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -1,0 +1,65 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+name: pkgdown
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  pkgdown:
+    runs-on: windows-latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      CUSTOM_DR_UA: 'GitHub_CI'
+    steps:
+      - uses: actions/checkout@c0a81a463886bb75afe234e07a9fd5bb79219196
+
+      - uses: r-lib/actions/setup-pandoc@52330cc136b963487918a8867f948ddf954e9e63
+
+      - uses: r-lib/actions/setup-r@52330cc136b963487918a8867f948ddf954e9e63
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@52330cc136b963487918a8867f948ddf954e9e63
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+
+      - name: Build site
+        run: |
+          pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE, dest_dir = "public") |
+          file.copy(from = "./public/articles/logo.png",to = "./public/reference/logo.png")
+        shell: Rscript {0}
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@64bcae551a7b18bcb9a09042ddf1960979799187
+        with:
+          path: ./public
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: pkgdown
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@73e62e651178eeba977de2dc9f4c7645b3d01015


### PR DESCRIPTION
This gets our actions working with a r-lib based set of github actions. I also split the pkgdown build / deploy out into it's own workflow for simplicity. 

The deploy step broke on my fork but it should "just work" here... 🤞 

For the record, this runs with "--no-manual --as-cran" 