### PR TITLE
handle zarr at a domain without context

### DIFF
--- a/R/stores.R
+++ b/R/stores.R
@@ -439,7 +439,8 @@ HttpStore <- R6::R6Class("HttpStore",
 
       segments <- stringr::str_split(private$url, "/")[[1]]
       private$domain <- paste(segments[1:3], collapse="/")
-      
+      # Support both cases in which the store is located at the root
+      # of the domain, or located under some base_path.
       private$base_path <- ifelse(length(segments) == 3, "", 
                                   paste(segments[4:length(segments)], collapse="/"))
       

--- a/R/stores.R
+++ b/R/stores.R
@@ -439,7 +439,9 @@ HttpStore <- R6::R6Class("HttpStore",
 
       segments <- stringr::str_split(private$url, "/")[[1]]
       private$domain <- paste(segments[1:3], collapse="/")
-      private$base_path <- paste(segments[4:length(segments)], collapse="/")
+      
+      private$base_path <- ifelse(length(segments) == 3, "", 
+                                  paste(segments[4:length(segments)], collapse="/"))
       
       if(!requireNamespace("crul", quietly = TRUE)) {
         stop("HttpStore requires the crul package")


### PR DESCRIPTION
There is a public dataset here: "https://noaa-nwm-retro-v2-zarr-pds.s3.amazonaws.com/" that wasn't working and I tracked it down to the minor issue here.