### PR TITLE
Improve sample pulls and clean up.

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -10,13 +10,22 @@
 #' @return path to ready to use zarr store
 #' @export
 #' @examples
-#' zarr_samples <- pizzarr_sample()
+#' 
+#' sample_dir <- tools::R_user_dir("pizzarr")
+#' 
+#' clean <- !dir.exists(sample_dir)
+#' 
+#' zarr_samples <- pizzarr_sample(outdir = sample_dir)
 #' 
 #' #printing without system path for example
-#' gsub(tempdir(), "...", zarr_samples, fixed = TRUE)
+#' gsub(sample_dir, "...", zarr_samples, fixed = TRUE)
+#' 
+#' # clean up if you don't want to keep them for next time
+#' if(clean) unlink(sample_dir, recursive = TRUE)
 #' 
 pizzarr_sample <- function(dataset = NULL, 
-                           outdir = file.path(tempdir(TRUE), "pizzarr_sample")) {
+                           outdir = file.path(tools::R_user_dir("pizzarr"), 
+                                              "pizzarr_sample")) {
   # will unzip here
   tdir <- outdir
   dir.create(tdir, showWarnings = FALSE, recursive = TRUE)
@@ -45,7 +54,9 @@ pizzarr_sample <- function(dataset = NULL,
   # in case zarr_zips is all, loop over them and unzip
   for(z in seq_along(zarr_zips)) {
     
-    if(file.size(zarr_zips[z]) == 0) {
+    need <- !file.exists(file.path(tdir, avail[z]))
+    
+    if(file.size(zarr_zips[z]) == 0 & need) {
       
       new_z <- file.path(tdir, basename(zarr_zips[z]))
 
@@ -56,8 +67,8 @@ pizzarr_sample <- function(dataset = NULL,
       zarr_zips[z] <- new_z
     }
      
-    utils::unzip(zarr_zips[z], 
-                 exdir = file.path(tdir, dirname(avail[z])))
+    if(need)
+      utils::unzip(zarr_zips[z], exdir = file.path(tdir, dirname(avail[z])))
   }
   
   return(file.path(tdir, avail))

--- a/man/pizzarr_sample.Rd
+++ b/man/pizzarr_sample.Rd
@@ -6,7 +6,7 @@
 \usage{
 pizzarr_sample(
   dataset = NULL,
-  outdir = file.path(tempdir(TRUE), "pizzarr_sample")
+  outdir = file.path(tools::R_user_dir("pizzarr"), "pizzarr_sample")
 )
 }
 \arguments{
@@ -26,9 +26,17 @@ For directory stores, unzips the store to a temporary directory
 and returns the resulting path.
 }
 \examples{
-zarr_samples <- pizzarr_sample()
+
+sample_dir <- tools::R_user_dir("pizzarr")
+
+clean <- !dir.exists(sample_dir)
+
+zarr_samples <- pizzarr_sample(outdir = sample_dir)
 
 #printing without system path for example
-gsub(tempdir(), "...", zarr_samples, fixed = TRUE)
+gsub(sample_dir, "...", zarr_samples, fixed = TRUE)
+
+# clean up if you don't want to keep them for next time
+if(clean) unlink(sample_dir, recursive = TRUE)
 
 }

--- a/tests/testthat/test-compat.R
+++ b/tests/testthat/test-compat.R
@@ -1,5 +1,8 @@
 library(pizzarr)
 
+sample_dir <- tools::R_user_dir("pizzarr")
+clean <- !dir.exists(sample_dir)
+
 test_that("Can open Zarr group using convenience function", {
 
     root <- pizzarr_sample(file.path("fixtures", "v2", "data.zarr"))
@@ -514,3 +517,5 @@ test_that("Can create 0-element 2D array", {
     expect_equal(length(sel$data), 0)
     expect_equal(dim(sel$data), c(0, 0))
 })
+
+if(clean) unlink(sample_dir, recursive = TRUE)

--- a/tests/testthat/test-get.R
+++ b/tests/testthat/test-get.R
@@ -1,5 +1,8 @@
 library(pizzarr)
 
+sample_dir <- tools::R_user_dir("pizzarr")
+clean <- !dir.exists(sample_dir)
+
 test_that("get_basic_selection_zd", {
     # Reference: https://github.com/zarr-developers/zarr-python/blob/5dd4a0e6cdc04c6413e14f57f61d389972ea937c/zarr/tests/test_indexing.py#L70
     a <- as_scalar(42)
@@ -270,3 +273,5 @@ test_that("Can read 2D string array", {
     expected_arr <- t(array(data = c(row1, row2, row3, row4, row5), dim = c(10, 5)))
     expect_equal(expected_arr, data)
 })
+
+if(clean) unlink(sample_dir, recursive = TRUE)

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,5 +1,8 @@
 library(pizzarr)
 
+sample_dir <- tools::R_user_dir("pizzarr")
+clean <- !dir.exists(sample_dir)
+
 test_that("demo data", {
   
   demo_data <- pizzarr_sample()
@@ -216,3 +219,5 @@ test_that("NaN in json", {
   
   expect_warning(try_fromJSON("borked", "test warning"), "test warning")
 })
+
+if(clean) unlink(sample_dir, recursive = TRUE)

--- a/vignettes/basics.Rmd
+++ b/vignettes/basics.Rmd
@@ -13,6 +13,8 @@ vignette: >
   comment = "#>",
   out.width = "100%"
 )
+sample_dir <- tools::R_user_dir("pizzarr")
+clean <- !dir.exists(sample_dir)
 ```
 
 ## Load the package
@@ -122,4 +124,7 @@ a <- z$get_item("4")
 class(a)
 
 a$get_attrs()$to_list()
+```
+```{r, include=FALSE}
+if(clean) unlink(sample_dir, recursive = TRUE)
 ```

--- a/vignettes/parallel.Rmd
+++ b/vignettes/parallel.Rmd
@@ -14,6 +14,8 @@ vignette: >
   out.width = "100%"
 )
 library(pizzarr)
+sample_dir <- tools::R_user_dir("pizzarr")
+clean <- !dir.exists(sample_dir)
 ```
 
 By default, reads and writes are performed sequentially (i.e., not in parallel).
@@ -138,4 +140,8 @@ To re-enable, run:
 
 ```{r}
 pbapply::pboptions(type = "timer")
+```
+
+```{r, include=FALSE}
+if(clean) unlink(sample_dir, recursive = TRUE)
 ```


### PR DESCRIPTION
This is much improved and I'm doing some clean up in case CRAN review cares that we leave a few files outside of temp.

We should decide on a better place to store the sample data download(s). Maybe in a release artifact? 