### PR TITLE
Graceful http handling fixes #128

### DIFF
--- a/R/numcodecs.R
+++ b/R/numcodecs.R
@@ -58,6 +58,7 @@ ZstdCodec <- R6::R6Class("ZstdCodec",
     #' @description
     #' Create a new ZSTD compressor.
     #' @param level The compression level, between 1 and 22.
+    #' @param ... not used
     #' @return A new `ZstdCodec` object.
     initialize = function(level = 1, ...) {
       self$level <- level
@@ -112,6 +113,7 @@ Lz4Codec <- R6::R6Class("Lz4Codec",
      #' @description
      #' Create a new LZ4 compressor.
      #' @param acceleration The compression level.
+     #' @param ... not used
      #' @return A new `Lz4Codec` object.
      initialize = function(acceleration = 1, ...) {
        self$acceleration <- acceleration
@@ -175,6 +177,7 @@ ZlibCodec <- R6::R6Class("ZlibCodec",
      #' @description
      #' Create a new Zlib compressor.
      #' @param level The compression level, between 1 and 22.
+     #' @param ... not used
      #' @return A new `ZlibCodec` object.
      initialize = function(level = 6, ...) {
       self$level <- level
@@ -237,6 +240,7 @@ GzipCodec <- R6::R6Class("GzipCodec",
      #' Create a new Gzip compressor.
      #' @param level The compression level, between 1 and 22.
      #' @return A new `GzipCodec` object.
+     #' @param ... not used
      initialize = function(level = 6, ...) {
       # No config options for gzip.
       self$level <- level
@@ -294,6 +298,7 @@ Bz2Codec <- R6::R6Class("Bz2Codec",
      #' @description
      #' Create a new Bz2 compressor.
      #' @param level The compression level, between 1 and 22.
+     #' @param ... not used
      #' @return A new `Bz2Codec` object.
      initialize = function(level = 6, ...) {
       # No config options for bz2.
@@ -355,6 +360,7 @@ LzmaCodec <- R6::R6Class("LzmaCodec",
      #' Create a new lzma compressor.
      #' @param level The compression level, between 1 and 22.
      #' @param format only 1 is supported
+     #' @param ... not used
      #' @return A new `LzmaCodec` object.
      initialize = function(level = 9, format = 1, ...) {
       # No config options for lzma.
@@ -427,6 +433,7 @@ BloscCodec <- R6::R6Class("BloscCodec",
     #' @param clevel The compression level.
     #' @param shuffle The shuffle filter to use.
     #' @param blocksize The block size.
+    #' @param ... not used
     #' @return A new `BloscCodec` object.
     initialize = function(cname = "lz4", clevel = 5, shuffle = TRUE, blocksize = NA, ...) {
       self$cname <- cname

--- a/R/stores.R
+++ b/R/stores.R
@@ -401,6 +401,11 @@ HttpStore <- R6::R6Class("HttpStore",
         return(unclass(res$responses())[[1]])
       }
       
+      # Despite getOption above, when running in parallel, options may not be passed to workers as expected.
+      # For this reason, if the `private$client$get` fails, which is known to not work in parallel,
+      # then we first guess that the failure is due to running in a worker (despite is_parallel being false).
+      # Reference: https://github.com/keller-mark/pizzarr/issues/128
+      
       if(is_parallel) {
         
         return(parallel_get(path))

--- a/R/stores.R
+++ b/R/stores.R
@@ -385,7 +385,7 @@ HttpStore <- R6::R6Class("HttpStore",
       parallel_option <- parse_parallel_option(parallel_option)
       is_parallel <- is_truthy_parallel_option(parallel_option)
 
-      if(is_parallel) {
+      parallel_get <- function(path) {
         # For some reason, the crul::HttpClient fails in parallel settings
         # This alternative
         # with HttpRequest and AsyncVaried seems to work.
@@ -399,10 +399,37 @@ HttpStore <- R6::R6Class("HttpStore",
         res <- crul::AsyncVaried$new(req)
         res$request()
         return(unclass(res$responses())[[1]])
+      }
+      
+      if(is_parallel) {
+        
+        return(parallel_get(path))
+        
       } else {
-        ret <- NULL
-        try(ret <- private$client$get(path = path))
-        if(is.null(ret)) warning("Can't procede, web request failed.")
+        
+        ret <- tryCatch(private$client$get(path = path),
+                        error = function(e) {
+                          
+                          # if the error involves a bad handle
+                          if(inherits(e, "simpleError") &&
+                             !is.null(e$message) &&
+                             grepl("handle", e$message)) {
+                            
+                            warning("http request issue, are we running in parallel? \n",
+                                    "set parallel options in environment variables or .Rprofile \n",
+                                    "trying fallback method")
+                            
+                            tryCatch(parallel_get(path), 
+                                     error = function(e2) {
+                                       warning("Can't procede, web request failed. Error was:", e2)
+                                       NULL
+                                     })
+                          } else {
+                            warning("Can't procede, web request failed. Error was:", e)
+                            NULL
+                          }
+                        })
+        
         return(ret)
       }
     },

--- a/R/zarr-array.R
+++ b/R/zarr-array.R
@@ -1314,12 +1314,14 @@ get_parallel_settings <- function(on_windows = (.Platform$OS.type == "windows"),
         if(progress) {
           apply_func <- function(X, FUN, ..., cl = NULL) {
             pbapply::pblapply(X, FUN, ..., 
+                              future.globals = FALSE,
                               future.packages = "Rarr",
                               future.seed = TRUE, cl = cl)
           }
         } else {
           apply_func <- function(X, FUN, ..., cl = NULL) {
             future.apply::future_lapply(X, FUN, ..., 
+                                        future.globals = FALSE,
                                         future.packages = "Rarr",
                                         future.seed=TRUE)
           }

--- a/man/BloscCodec.Rd
+++ b/man/BloscCodec.Rd
@@ -42,7 +42,7 @@ Blosc compressor for Zarr
 \subsection{Method \code{new()}}{
 Create a new Blosc compressor.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{BloscCodec$new(cname = "lz4", clevel = 5, shuffle = TRUE, blocksize = NA)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{BloscCodec$new(cname = "lz4", clevel = 5, shuffle = TRUE, blocksize = NA, ...)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -55,6 +55,8 @@ Create a new Blosc compressor.
 \item{\code{shuffle}}{The shuffle filter to use.}
 
 \item{\code{blocksize}}{The block size.}
+
+\item{\code{...}}{not used}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/Bz2Codec.Rd
+++ b/man/Bz2Codec.Rd
@@ -36,13 +36,15 @@ Bz2 compressor for Zarr
 \subsection{Method \code{new()}}{
 Create a new Bz2 compressor.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Bz2Codec$new(level = 6)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Bz2Codec$new(level = 6, ...)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{level}}{The compression level, between 1 and 22.}
+
+\item{\code{...}}{not used}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/GzipCodec.Rd
+++ b/man/GzipCodec.Rd
@@ -36,13 +36,15 @@ Gzip compressor for Zarr
 \subsection{Method \code{new()}}{
 Create a new Gzip compressor.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{GzipCodec$new(level = 6)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{GzipCodec$new(level = 6, ...)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{level}}{The compression level, between 1 and 22.}
+
+\item{\code{...}}{not used}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/Lz4Codec.Rd
+++ b/man/Lz4Codec.Rd
@@ -37,13 +37,15 @@ LZ4 compressor for Zarr
 \subsection{Method \code{new()}}{
 Create a new LZ4 compressor.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Lz4Codec$new(acceleration = 1)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Lz4Codec$new(acceleration = 1, ...)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{acceleration}}{The compression level.}
+
+\item{\code{...}}{not used}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/LzmaCodec.Rd
+++ b/man/LzmaCodec.Rd
@@ -38,7 +38,7 @@ Lzma compressor for Zarr
 \subsection{Method \code{new()}}{
 Create a new lzma compressor.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{LzmaCodec$new(level = 9, format = 1)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{LzmaCodec$new(level = 9, format = 1, ...)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -47,6 +47,8 @@ Create a new lzma compressor.
 \item{\code{level}}{The compression level, between 1 and 22.}
 
 \item{\code{format}}{only 1 is supported}
+
+\item{\code{...}}{not used}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/ZlibCodec.Rd
+++ b/man/ZlibCodec.Rd
@@ -36,13 +36,15 @@ Zlib compressor for Zarr
 \subsection{Method \code{new()}}{
 Create a new Zlib compressor.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{ZlibCodec$new(level = 6)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{ZlibCodec$new(level = 6, ...)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{level}}{The compression level, between 1 and 22.}
+
+\item{\code{...}}{not used}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/ZstdCodec.Rd
+++ b/man/ZstdCodec.Rd
@@ -37,13 +37,15 @@ ZSTD compressor for Zarr
 \subsection{Method \code{new()}}{
 Create a new ZSTD compressor.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{ZstdCodec$new(level = 1)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{ZstdCodec$new(level = 1, ...)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{level}}{The compression level, between 1 and 22.}
+
+\item{\code{...}}{not used}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-01-parallel.R
+++ b/tests/testthat/test-01-parallel.R
@@ -173,6 +173,7 @@ test_that("get_parallel_settings", {
   expect_equal(format(ps$apply_func), 
                format(function(X, FUN, ..., cl = NULL) {
                  pbapply::pblapply(X, FUN, ..., 
+                                   future.globals = FALSE,
                                    future.packages = "Rarr",
                                    future.seed = TRUE, cl = cl)
                }))
@@ -187,6 +188,7 @@ test_that("get_parallel_settings", {
   expect_equal(format(ps$apply_func), 
                format(function(X, FUN, ..., cl = NULL) {
                  future.apply::future_lapply(X, FUN, ..., 
+                                             future.globals = FALSE,
                                              future.packages = "Rarr",
                                              future.seed=TRUE)
                }))

--- a/tests/testthat/test-http-store.R
+++ b/tests/testthat/test-http-store.R
@@ -85,6 +85,8 @@ test_that("http broken", {
   
   url<- "https://nogonnawork.zarr"
   
+  options(pizzarr.parallel_backend = NA)
+  
   expect_warning(z <- pizzarr::HttpStore$new(url), "Can't procede, web request failed.")
   expect_equal(class(z), c("HttpStore", "Store", "R6"))
 
@@ -94,8 +96,7 @@ test_that("http broken", {
 
   w <- capture_warnings(g <- pizzarr::zarr_open_group(z))
  
-  expect_equal(w, c("Can't procede, web request failed.", 
-                    "Can't procede, web request failed."))
+  expect_true(all(grepl("Can't procede", w)))
 })
 
 vcr::use_cassette("http_github_pattern", {


### PR DESCRIPTION
Sorry for the git confusion... this is a clean PR.

Note that the undocumented `...` was throwing warnings in the build.

Testing this is tricky as it is both parallel and network required. It illustrates the need for us to get a stable set of http testing resources finalized. I stubbed my toe on using the docs folder since it doesn't deploy with pkgdown and we now have some diverse (and stale) urls in the tests. 

So for now, the warning / retry stuff is not tested but it could be once we have that situation more cleaned up.