### PR TITLE
bump rustls-webpki 0.103.12 -> 0.103.13

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -1950,9 +1950,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
- Patches [GHSA-82j2-j2ch-gfr8](https://github.com/zarr-developers/pizzarr/security/dependabot/6) (CVSS 7.5): rustls-webpki panic on malformed CRL BIT STRING.
- Transitive dep via zarrs_http → reqwest → rustls. Bump is a single-line `cargo update -p rustls-webpki`.
- Not exploitable in pizzarr (we never pass `RevocationOptions`), but clears the Dependabot alert.

## Test plan
- [ ] CI green on `main` after merge
- [ ] r-universe rebuild picks up the patched lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)