### PR TITLE
Improve r-universe build

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pizzarr
 Type: Package
 Title: Slice into 'Zarr' Arrays
-Version: 0.2.0
+Version: 0.2.1.9000
 Authors@R: c(
     person(given = "David",
            family = "Blodgett",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# pizzarr 0.2.0-pre
+# pizzarr 0.2.0
 
 ## Two-tier distribution
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -52,9 +52,9 @@ pre-compiled binaries for Windows and macOS — no Rust toolchain needed.
 
 The r-universe binaries compile the zarrs backend with local filesystem I/O,
 synchronous HTTP reads, gzip/zstd/blosc codecs, sharding, and S3/GCS cloud
-store support via `object_store`. The build system enables these features
-automatically when `NOT_CRAN` is set (which r-universe does). To compile with
-a different feature set, set `PIZZARR_FEATURES` explicitly (see below).
+store support via `object_store`. Any build that compiles Rust enables these
+features by default. To compile with a different feature set, set
+`PIZZARR_FEATURES` explicitly (see below).
 
 `pizzarr_compiled_features()` lists what the zarrs backend provides, and
 `pizzarr_upgrade()` prints the install command when zarrs is not compiled in.
@@ -80,10 +80,10 @@ The build system uses two environment variables to control compilation:
   skips link-time optimization and does not strip symbols. Use this during
   active development on the Rust code.
 - **`PIZZARR_FEATURES`** — a comma-separated list of extra Cargo features.
-  When `NOT_CRAN` is set and `PIZZARR_FEATURES` is empty, the build defaults
-  to `s3,gcs` (S3 and GCS cloud store support via `object_store` and `tokio`).
-  Set this explicitly to override — e.g., `PIZZARR_FEATURES=none` for default
-  features only, or `PIZZARR_FEATURES=s3` for S3 without GCS.
+  When unset, the build defaults to `s3,gcs` (S3 and GCS cloud store support
+  via `object_store` and `tokio`, which also pulls in blosc and sharding).
+  Set this explicitly to override — e.g., `PIZZARR_FEATURES=none` for Cargo's
+  default features only, or `PIZZARR_FEATURES=s3` for S3 without GCS.
 
 A release build (no `DEBUG`) uses LTO, single codegen unit, and symbol
 stripping — fast at runtime but takes several minutes to compile from scratch.
@@ -93,15 +93,15 @@ stripping — fast at runtime but takes several minutes to compile from scratch.
 DEBUG=1 R CMD INSTALL .
 
 # Production: slow first build, fast runtime, S3/GCS included
-NOT_CRAN=true R CMD INSTALL .
-
-# Production with default features only (no cloud stores)
 R CMD INSTALL .
+
+# Production with Cargo default features only (no cloud stores)
+PIZZARR_FEATURES=none R CMD INSTALL .
 ```
 
-`NOT_CRAN` is set automatically when `DEBUG` is present. For builds without
-vendored crates (the normal case for local development), `NOT_CRAN` prevents
-the build system from attempting offline compilation.
+`NOT_CRAN=true` opts builds out of the offline-vendored-crates path used for
+CRAN; it's set automatically when `DEBUG` is present and only matters when
+`src/rust/vendor.tar.xz` is also present.
 
 Development happens on the `develop` branch. See
 [CONTRIBUTING.md](https://github.com/zarr-developers/pizzarr/blob/main/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -41,10 +41,9 @@ toolchain needed.
 
 The r-universe binaries compile the zarrs backend with local
 filesystem I/O, synchronous HTTP reads, gzip/zstd/blosc codecs,
-sharding, and S3/GCS cloud store support via `object_store`. The
-build system enables these features automatically when `NOT_CRAN` is
-set (which r-universe does). To compile with a different feature set,
-set `PIZZARR_FEATURES` explicitly (see below).
+sharding, and S3/GCS cloud store support via `object_store`. Any build
+that compiles Rust enables these features by default. To compile with
+a different feature set, set `PIZZARR_FEATURES` explicitly (see below).
 
 `pizzarr_compiled_features()` lists what the zarrs backend provides,
 and `pizzarr_upgrade()` prints the install command when zarrs is not
@@ -71,10 +70,10 @@ The build system uses two environment variables to control compilation:
   runtime because it skips link-time optimization and does not strip
   symbols. Use this during active development on the Rust code.
 - **`PIZZARR_FEATURES`** — a comma-separated list of extra Cargo
-  features. When `NOT_CRAN` is set and `PIZZARR_FEATURES` is empty,
-  the build defaults to `s3,gcs` (S3 and GCS cloud store support via
-  `object_store` and `tokio`). Set this explicitly to override — e.g.,
-  `PIZZARR_FEATURES=none` for default features only, or
+  features. When unset, the build defaults to `s3,gcs` (S3 and GCS
+  cloud store support via `object_store` and `tokio`, which also pulls
+  in blosc and sharding). Set this explicitly to override — e.g.,
+  `PIZZARR_FEATURES=none` for Cargo's default features only, or
   `PIZZARR_FEATURES=s3` for S3 without GCS.
 
 A release build (no `DEBUG`) uses LTO, single codegen unit, and symbol
@@ -86,16 +85,15 @@ scratch.
 DEBUG=1 R CMD INSTALL .
 
 # Production: slow first build, fast runtime, S3/GCS included
-NOT_CRAN=true R CMD INSTALL .
-
-# Production with default features only (no cloud stores)
 R CMD INSTALL .
+
+# Production with Cargo default features only (no cloud stores)
+PIZZARR_FEATURES=none R CMD INSTALL .
 ```
 
-`NOT_CRAN` is set automatically when `DEBUG` is present. For builds
-without vendored crates (the normal case for local development),
-`NOT_CRAN` prevents the build system from attempting offline
-compilation.
+`NOT_CRAN=true` opts builds out of the offline-vendored-crates path
+used for CRAN; it's set automatically when `DEBUG` is present and only
+matters when `src/rust/vendor.tar.xz` is also present.
 
 Development happens on the `develop` branch. See
 [CONTRIBUTING.md](https://github.com/zarr-developers/pizzarr/blob/main/CONTRIBUTING.md)

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: https://zarr-developers.github.io/pizzarr/
+url: https://zarr.dev/pizzarr/
 
 template:
   bootstrap: 5
@@ -38,6 +38,8 @@ reference:
   - DirectoryStore
   - MemoryStore
   - HttpStore
+  - S3Store
+  - GcsStore
 - title: "Compressors and filters"
   desc: >
     Codec classes for compressing and decompressing chunk data. Each codec
@@ -70,6 +72,7 @@ reference:
   - zarr_create_zeros
   - zarr_create_array
   - zarr_create_group
+  - pizzarr_config
   - zarr_open
   - zarr_open_group
   - zarr_open_array
@@ -101,11 +104,14 @@ reference:
   - pizzarr_upgrade
   - zarrs_close_store
   - zarrs_compiled_features
+  - zarrs_create_array
   - zarrs_get_subset
   - zarrs_node_exists
   - zarrs_open_array_metadata
   - zarrs_runtime_info
   - zarrs_set_codec_concurrent_target
+  - zarrs_set_http_batch_range_requests
+  - zarrs_set_nthreads
   - zarrs_set_subset
 
 
@@ -118,7 +124,6 @@ articles:
       - ome-ngff
       - remote-ome-ngff
       - remote-anndata
-      - parallel
       - v3-read
       - v3-interop
       - zarrs-backend

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -1412,9 +1412,9 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl"
-version = "0.10.77"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1444,9 +1444,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.113"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -1412,15 +1412,14 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -1444,9 +1443,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",

--- a/tools/config.R
+++ b/tools/config.R
@@ -71,16 +71,17 @@ if (!is_not_cran) {
 # when DEBUG env var is present we use `--debug` build
 .profile <- ifelse(is_debug, "", "--release")
 
-# PIZZARR_FEATURES env var enables extra Cargo features (e.g., "s3,gcs").
-# When NOT_CRAN is set (r-universe, DEBUG) and PIZZARR_FEATURES is empty,
-# default to "s3,gcs" so r-universe binaries ship with cloud store support.
-if (!nzchar(env_features) && is_not_cran) {
+# PIZZARR_FEATURES env var enables extra Cargo features. When unset, default
+# to "s3,gcs" so every Rust build ships with cloud store + blosc + sharding
+# support. The CRAN tier is the pure-R tarball produced by tools/cran-build.sh
+# (src/ stripped), so this default never reaches CRAN — it only affects builds
+# that actually compile Rust (r-universe binaries, local source installs).
+if (!nzchar(env_features)) {
   env_features <- "s3,gcs"
-  message("Defaulting PIZZARR_FEATURES to '", env_features, "' (NOT_CRAN build).")
+  message("Defaulting PIZZARR_FEATURES to '", env_features, "'.")
 }
 
-# "none" is an escape hatch: suppresses the NOT_CRAN default without
-# passing any extra features to Cargo.
+# "none" is an escape hatch: build with Cargo's default features only.
 if (identical(env_features, "none")) {
   env_features <- ""
   message("PIZZARR_FEATURES='none': using default Cargo features only.")


### PR DESCRIPTION
## Summary

Adds gcs, s3, and blosc to default Rust build. Fixes to #185 

## Test plan

Once build on r-universe, install and verify features are available.
